### PR TITLE
feat: implement markdown import/export with flashcards support (#7)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
       "name": "Debug Backend",
       "skipFiles": ["<node_internals>/**"],
       "program": "${workspaceFolder}/backend/src/index.ts",
-      "runtimeArgs": ["-r", "ts-node/register"],
+      "runtimeExecutable": "${workspaceFolder}/backend/node_modules/.bin/ts-node",
       "sourceMaps": true,
       "resolveSourceMapLocations": [
         "${workspaceFolder}/**",
@@ -18,7 +18,8 @@
         "NODE_ENV": "development"
       },
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "cwd": "${workspaceFolder}/backend"
     },
     {
       "type": "node",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,9 +14,12 @@
         "cross-fetch": "^3.1.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "gray-matter": "^4.0.3",
         "langchain": "^0.3.19",
+        "multer": "^1.4.5-lts.1",
         "uuid": "^9.0.1",
         "web-streams-polyfill": "^3.2.1",
+        "yaml": "^2.7.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -24,7 +27,8 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.12",
-        "@types/node": "^20.11.24",
+        "@types/multer": "^1.4.12",
+        "@types/node": "^20.17.24",
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
         "nodemon": "^3.1.0",
@@ -1411,10 +1415,21 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
     },
+    "node_modules/@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.17.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
       "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -1607,6 +1622,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
     },
     "node_modules/archiver": {
       "version": "6.0.2",
@@ -1986,8 +2007,18 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2282,6 +2313,21 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/console-table-printer": {
       "version": "2.12.1",
@@ -2833,7 +2879,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2954,6 +2999,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fast-fifo": {
@@ -3279,6 +3336,43 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3481,6 +3575,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -4375,6 +4478,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -4535,33 +4647,6 @@
       },
       "engines": {
         "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/leven": {
@@ -4742,10 +4827,49 @@
         "node": ">=10"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/mustache": {
       "version": "4.2.0",
@@ -5405,6 +5529,36 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/readdir-glob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
@@ -5515,6 +5669,19 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -5731,8 +5898,7 @@
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -5752,6 +5918,14 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/streamx": {
@@ -5820,6 +5994,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -6047,6 +6230,7 @@
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6117,6 +6301,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.8.2",
@@ -6411,6 +6601,15 @@
         }
       }
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6430,6 +6629,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
       "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -7647,6 +7847,15 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
     },
+    "@types/multer": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-1.4.12.tgz",
+      "integrity": "sha512-pQ2hoqvXiJt2FP9WQVLPRO+AmiIm/ZYkavPlIQnx282u4ZrVdztx0pkh3jjpQt0Kz+YI0YhSG264y08UJKoUQg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/node": {
       "version": "20.17.24",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
@@ -7806,6 +8015,11 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
+    },
+    "append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
     },
     "archiver": {
       "version": "6.0.2",
@@ -8098,8 +8312,15 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
     },
     "bytes": {
       "version": "3.1.2",
@@ -8301,6 +8522,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "console-table-printer": {
       "version": "2.12.1",
@@ -8691,8 +8923,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "etag": {
       "version": "1.8.1",
@@ -8781,6 +9012,14 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      }
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "requires": {
+        "is-extendable": "^0.1.0"
       }
     },
     "fast-fifo": {
@@ -9008,6 +9247,36 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -9151,6 +9420,11 @@
       "requires": {
         "hasown": "^2.0.2"
       }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -9836,6 +10110,11 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
       "integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9895,35 +10174,6 @@
       "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "requires": {
         "readable-stream": "^2.0.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.8",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
       }
     },
     "leven": {
@@ -10059,10 +10309,37 @@
         "brace-expansion": "^2.0.1"
       }
     },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
+    "mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "requires": {
+        "minimist": "^1.2.6"
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "requires": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      }
     },
     "mustache": {
       "version": "4.2.0",
@@ -10522,6 +10799,35 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "readdir-glob": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
@@ -10591,6 +10897,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      }
     },
     "semver": {
       "version": "7.7.1",
@@ -10755,8 +11070,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "stack-utils": {
       "version": "2.0.6",
@@ -10771,6 +11085,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "streamx": {
       "version": "2.22.0",
@@ -10825,6 +11144,11 @@
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true
+    },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -11012,6 +11336,11 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "typescript": {
       "version": "5.8.2",
@@ -11211,6 +11540,11 @@
       "optional": true,
       "peer": true,
       "requires": {}
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,9 +25,12 @@
     "cross-fetch": "^3.1.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "gray-matter": "^4.0.3",
     "langchain": "^0.3.19",
+    "multer": "^1.4.5-lts.1",
     "uuid": "^9.0.1",
     "web-streams-polyfill": "^3.2.1",
+    "yaml": "^2.7.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
@@ -35,7 +38,8 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.12",
-    "@types/node": "^20.11.24",
+    "@types/multer": "^1.4.12",
+    "@types/node": "^20.17.24",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.0",

--- a/backend/src/controllers/importController.ts
+++ b/backend/src/controllers/importController.ts
@@ -1,0 +1,197 @@
+import { Request, Response } from 'express';
+import { z } from 'zod';
+import { noteService } from '../services/NoteService';
+import { MarkdownService } from '../services/MarkdownService';
+import { Note } from '../types/note';
+import multer from 'multer';
+
+// Configuration de multer pour le stockage temporaire des fichiers
+const storage = multer.memoryStorage();
+const fileFilter = (_req: Express.Request, file: Express.Multer.File, cb: multer.FileFilterCallback) => {
+    // Accepter uniquement les fichiers .md
+    if (file.mimetype === 'text/markdown' || file.originalname.endsWith('.md')) {
+        cb(null, true);
+    } else {
+        cb(null, false);
+    }
+};
+
+export const upload = multer({
+    storage,
+    fileFilter,
+    limits: {
+        fileSize: 5 * 1024 * 1024, // 5MB max
+        files: 10 // Maximum 10 fichiers à la fois
+    }
+}).any();
+
+// Middleware de gestion des erreurs Multer
+export const handleMulterError = (err: any, req: Request, res: Response, next: Function) => {
+    if (err instanceof multer.MulterError) {
+        if (err.code === 'LIMIT_FILE_SIZE') {
+            return res.status(400).json({
+                message: 'Fichier trop volumineux. Taille maximale : 5MB'
+            });
+        }
+        if (err.code === 'LIMIT_FILE_COUNT') {
+            return res.status(400).json({
+                message: 'Trop de fichiers. Maximum : 10 fichiers'
+            });
+        }
+        if (err.code === 'LIMIT_UNEXPECTED_FILE') {
+            return res.status(400).json({
+                message: 'Champ de fichier inattendu. Utilisez le champ "file" pour l\'upload de fichiers'
+            });
+        }
+        return res.status(400).json({
+            message: 'Erreur lors de l\'upload du fichier',
+            error: err.message
+        });
+    }
+    next(err);
+};
+
+// Schéma de validation des options d'import
+const ImportOptionsSchema = z.object({
+    overwrite: z.boolean().default(false),
+    skipDuplicates: z.boolean().default(true)
+});
+
+type ImportOptions = z.infer<typeof ImportOptionsSchema>;
+
+// Fonction utilitaire pour parser les options
+const parseImportOptions = (req: Request): ImportOptions => {
+    try {
+        const optionsJson = req.body.options;
+        if (!optionsJson) {
+            return ImportOptionsSchema.parse({});
+        }
+        const options = JSON.parse(optionsJson);
+        return ImportOptionsSchema.parse(options);
+    } catch (error) {
+        console.error('Erreur lors du parsing des options:', error);
+        return ImportOptionsSchema.parse({});
+    }
+};
+
+const markdownService = MarkdownService.getInstance();
+
+// Import d'une seule note
+export const importNote = async (req: Request, res: Response) => {
+    try {
+        if (!req.files || !Array.isArray(req.files) || req.files.length === 0) {
+            return res.status(400).json({ message: 'Aucun fichier fourni' });
+        }
+
+        const file = req.files[0];
+        const options = parseImportOptions(req);
+        const fileContent = file.buffer.toString('utf-8');
+        const parsedNote = markdownService.parseMarkdown(fileContent);
+
+        // Vérifier si une note avec le même titre existe déjà
+        const existingNote = await noteService.findNoteByTitle(parsedNote.title);
+
+        if (existingNote) {
+            if (options.skipDuplicates) {
+                return res.status(200).json({
+                    message: 'Note ignorée (doublon)',
+                    note: existingNote
+                });
+            }
+            if (!options.overwrite) {
+                return res.status(409).json({
+                    message: 'Une note avec ce titre existe déjà'
+                });
+            }
+            // Mise à jour de la note existante
+            const updatedNote = await noteService.updateNote(existingNote.id, parsedNote);
+            return res.status(200).json({
+                message: 'Note mise à jour avec succès',
+                note: updatedNote
+            });
+        }
+
+        // Création d'une nouvelle note
+        const newNote = await noteService.createNote(parsedNote);
+        res.status(201).json({
+            message: 'Note importée avec succès',
+            note: newNote
+        });
+    } catch (error) {
+        console.error('Erreur lors de l\'import:', error);
+        res.status(500).json({
+            message: 'Erreur lors de l\'import de la note',
+            error: error instanceof Error ? error.message : 'Unknown error'
+        });
+    }
+};
+
+// Import de plusieurs notes
+export const importMultipleNotes = async (req: Request, res: Response) => {
+    try {
+        if (!req.files || !Array.isArray(req.files)) {
+            return res.status(400).json({ message: 'Aucun fichier fourni' });
+        }
+
+        const options = parseImportOptions(req);
+        const results = {
+            success: 0,
+            skipped: 0,
+            failed: 0,
+            notes: [] as Note[]
+        };
+
+        for (const file of req.files) {
+            try {
+                const fileContent = file.buffer.toString('utf-8');
+                const parsedNote = markdownService.parseMarkdown(fileContent);
+
+                // Vérifier si une note avec le même titre existe déjà
+                const existingNote = await noteService.findNoteByTitle(parsedNote.title);
+
+                if (existingNote) {
+                    if (options.skipDuplicates) {
+                        results.skipped++;
+                        continue;
+                    }
+                    if (!options.overwrite) {
+                        results.failed++;
+                        continue;
+                    }
+                    // Mise à jour de la note existante
+                    const updatedNote = await noteService.updateNote(existingNote.id, parsedNote);
+                    if (updatedNote) {
+                        results.success++;
+                        results.notes.push(updatedNote);
+                    }
+                } else {
+                    // Création d'une nouvelle note
+                    const newNote = await noteService.createNote(parsedNote);
+                    results.success++;
+                    results.notes.push(newNote);
+                }
+            } catch (error) {
+                console.error(`Erreur lors de l'import du fichier ${file.originalname}:`, error);
+                results.failed++;
+            }
+        }
+
+        res.status(200).json({
+            message: 'Import terminé',
+            summary: results
+        });
+    } catch (error) {
+        console.error('Erreur lors de l\'import multiple:', error);
+        res.status(500).json({
+            message: 'Erreur lors de l\'import des notes',
+            error: error instanceof Error ? error.message : 'Unknown error'
+        });
+    }
+};
+
+export default {
+    importNote,
+    importMultipleNotes,
+    upload,
+    handleMulterError
+}; 

--- a/backend/src/routes/notes.ts
+++ b/backend/src/routes/notes.ts
@@ -1,35 +1,40 @@
 import express from 'express';
 import * as notesController from '../controllers/notesController';
 import { exportController } from '../controllers/exportController';
+import importController, { upload, handleMulterError } from '../controllers/importController';
 
 const router = express.Router();
 
-// Routes d'export
-router.get('/export-all', exportController.exportAllNotes);
-router.post('/export', exportController.exportMultipleNotes);
+// Routes CRUD basiques
+router.get('/', notesController.getAllNotes);
+router.post('/', notesController.createNote);
+router.put('/:id', notesController.updateNote);
+router.delete('/:id', notesController.deleteNote);
 
-// Route pour rechercher des notes
+// Routes de recherche
 router.get('/search', notesController.searchNotes);
 
-// Route pour obtenir toutes les notes
-router.get('/', notesController.getAllNotes);
+// Routes d'export
+router.get('/export-all', exportController.exportMultipleNotes);
+router.get('/:id/export', exportController.exportNote);
 
-// Route pour créer une nouvelle note
-router.post('/', notesController.createNote);
+// Routes d'import avec gestion des erreurs Multer
+router.post('/import',
+    upload,
+    handleMulterError,
+    importController.importNote
+);
+
+router.post('/import-bulk',
+    upload,
+    handleMulterError,
+    importController.importMultipleNotes
+);
 
 // Route pour obtenir une note spécifique par ID
 router.get('/:id', notesController.getNoteById);
 
-// Route pour exporter une note spécifique
-router.get('/:id/export', exportController.exportSingleNote);
-
 // Route pour obtenir les flashcards d'une note spécifique
 router.get('/:id/flashcards', notesController.getNoteFlashcards);
-
-// Route pour mettre à jour une note
-router.put('/:id', notesController.updateNote);
-
-// Route pour supprimer une note
-router.delete('/:id', notesController.deleteNote);
 
 export default router; 

--- a/backend/src/services/MarkdownExportService.ts
+++ b/backend/src/services/MarkdownExportService.ts
@@ -1,11 +1,15 @@
 import { Note } from '../types/note'
 import { FlashcardRepository, Flashcard } from '../storage/FlashcardRepository'
+import yaml from 'yaml';
+import { NoteRepository } from '../storage/NoteRepository';
 
 export class MarkdownExportService {
     private static instance: MarkdownExportService;
+    private noteRepo: NoteRepository;
     private flashcardRepo: FlashcardRepository;
 
     private constructor() {
+        this.noteRepo = NoteRepository.getInstance();
         this.flashcardRepo = FlashcardRepository.getInstance();
     }
 
@@ -16,87 +20,127 @@ export class MarkdownExportService {
         return MarkdownExportService.instance;
     }
 
-    private generateYAMLFrontmatter(note: Note): string {
-        const frontmatter = {
+    private formatFrontMatter(note: Note): string {
+        const frontMatter: Record<string, any> = {
             title: note.title,
             tags: note.tags,
-            created_at: note.metadata?.createdAt || new Date().toISOString(),
-            updated_at: note.metadata?.updatedAt || new Date().toISOString(),
+            createdAt: note.metadata?.createdAt || new Date().toISOString(),
+            updatedAt: note.metadata?.updatedAt || new Date().toISOString(),
             ...note.metadata
         };
 
-        const yamlLines = Object.entries(frontmatter)
-            .filter(([_, value]) => value !== undefined)
-            .map(([key, value]) => {
-                if (Array.isArray(value)) {
-                    return `${key}: [${value.map(v => `"${v}"`).join(', ')}]`;
-                }
-                return `${key}: "${value}"`;
-            });
+        // On retire ces champs car ils sont déjà au premier niveau
+        if ('createdAt' in frontMatter) delete frontMatter.createdAt;
+        if ('updatedAt' in frontMatter) delete frontMatter.updatedAt;
 
-        return ['---', ...yamlLines, '---'].join('\n');
-    }
-
-    private formatContent(content: string): string {
-        // Supprime les espaces et sauts de ligne inutiles
-        return content.trim()
-            .replace(/\n{3,}/g, '\n\n') // Remplace les multiples sauts de ligne par deux
-            .replace(/\s+$/gm, ''); // Supprime les espaces en fin de ligne
+        return yaml.stringify(frontMatter).trim();
     }
 
     private createFilename(note: Note): string {
-        // Crée un nom de fichier sécurisé basé sur le titre
         return note.title
             .toLowerCase()
-            .replace(/[^a-z0-9]+/g, '-') // Remplace les caractères non alphanumériques par des tirets
-            .replace(/^-+|-+$/g, '') // Supprime les tirets au début et à la fin
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
             + '.md';
     }
 
-    private async formatFlashcards(flashcards: Flashcard[]): Promise<string> {
+    private formatFlashcards(flashcards: Flashcard[]): string {
         if (flashcards.length === 0) {
             return '';
         }
 
-        const lines = [
-            '\n## Flashcards\n',
-            ...flashcards.map((fc, index) => [
-                `### Flashcard ${index + 1}`,
-                '**Question:**',
-                fc.question,
-                '',
-                '**Réponse:**',
-                fc.answer,
-                ''
-            ].join('\n'))
-        ];
-
-        return lines.join('\n');
+        return flashcards.map(fc => (
+            `### Question\n${fc.question}\n\n### Réponse\n${fc.answer}`
+        )).join('\n\n');
     }
 
-    public async exportNote(note: Note): Promise<string> {
-        // Récupérer les flashcards associées à la note
-        const flashcards = await this.flashcardRepo.getFlashcardsByNoteId(note.id!);
-
-        const parts = [
-            this.generateYAMLFrontmatter(note),
-            '',
-            this.formatContent(note.content)
-        ];
-
-        // Ajouter les flashcards si elles existent
-        if (flashcards.length > 0) {
-            parts.push(await this.formatFlashcards(flashcards));
+    public async exportNote(noteId: string): Promise<{ markdown: string; filename: string }> {
+        const note = await this.noteRepo.getNoteById(noteId);
+        if (!note) {
+            throw new Error('Note non trouvée');
         }
 
-        return parts.join('\n');
+        const flashcards = await this.flashcardRepo.getFlashcardsByNoteId(noteId);
+        const markdown = this.formatNote(note, flashcards);
+        const filename = this.createFilename(note);
+
+        return { markdown, filename };
+    }
+
+    public async exportAllNotes(): Promise<string> {
+        const notes = await this.noteRepo.getAllNotes();
+        if (notes.length === 0) {
+            throw new Error('Aucune note trouvée');
+        }
+
+        const exports = await Promise.all(
+            notes.map(async note => {
+                const flashcards = await this.flashcardRepo.getFlashcardsByNoteId(note.id);
+                return this.formatNote(note, flashcards);
+            })
+        );
+
+        return exports.join('\n\n---\n\n');
+    }
+
+    private formatNote(note: Note, flashcards: Flashcard[]): string {
+        const sections = [
+            '---',
+            this.formatFrontMatter(note),
+            '---',
+            '',
+            '# ' + note.title,
+            ''
+        ];
+
+        // Ajouter les tags s'il y en a
+        if (note.tags.length > 0) {
+            sections.push('## Tags');
+            sections.push('');
+            sections.push(note.tags.map(tag => `- ${tag}`).join('\n'));
+            sections.push('');
+        }
+
+        // Ajouter le contenu principal
+        sections.push('## Contenu');
+        sections.push('');
+        sections.push(note.content.trim());
+
+        // Ajouter les flashcards s'il y en a
+        if (flashcards.length > 0) {
+            sections.push('');
+            sections.push('## Flashcards');
+            sections.push('');
+            sections.push(this.formatFlashcards(flashcards));
+        }
+
+        // Ajouter les métadonnées
+        sections.push('');
+        sections.push('## Métadonnées');
+        sections.push('');
+        sections.push(`- Date de création : ${note.metadata?.createdAt || new Date().toISOString()}`);
+        sections.push(`- Dernière modification : ${note.metadata?.updatedAt || new Date().toISOString()}`);
+
+        // Ajouter les autres métadonnées s'il y en a
+        const otherMetadata = { ...note.metadata };
+        delete otherMetadata.createdAt;
+        delete otherMetadata.updatedAt;
+
+        if (Object.keys(otherMetadata).length > 0) {
+            Object.entries(otherMetadata).forEach(([key, value]) => {
+                sections.push(`- ${key} : ${value}`);
+            });
+        }
+
+        return sections.join('\n');
     }
 
     public async exportNotes(notes: Note[]): Promise<Map<string, string>> {
         const exports = new Map<string, string>();
 
         for (const note of notes) {
-            const content = await this.exportNote(note);
+            const flashcards = await this.flashcardRepo.getFlashcardsByNoteId(note.id);
+            const content = this.formatNote(note, flashcards);
             const filename = this.createFilename(note);
             exports.set(filename, content);
         }

--- a/backend/src/services/MarkdownImportService.ts
+++ b/backend/src/services/MarkdownImportService.ts
@@ -1,0 +1,231 @@
+import { Note } from '../types/note';
+import { Flashcard } from '../storage/FlashcardRepository';
+import { MarkdownParseResult, MarkdownParseError, MarkdownImportResult } from '../types/markdown';
+import { v4 as uuidv4 } from 'uuid';
+import yaml from 'yaml';
+
+export class MarkdownImportService {
+    private static instance: MarkdownImportService;
+
+    private constructor() { }
+
+    public static getInstance(): MarkdownImportService {
+        if (!MarkdownImportService.instance) {
+            MarkdownImportService.instance = new MarkdownImportService();
+        }
+        return MarkdownImportService.instance;
+    }
+
+    /**
+     * Parse le contenu d'un fichier Markdown et extrait les données
+     */
+    public parseMarkdown(content: string): MarkdownParseResult {
+        const errors: MarkdownParseError[] = [];
+        let currentLine = 1;
+
+        try {
+            // Vérifier si le contenu commence par un frontmatter YAML
+            if (!content.startsWith('---')) {
+                errors.push({
+                    line: 1,
+                    message: 'Le fichier doit commencer par un frontmatter YAML (---)',
+                    type: 'error'
+                });
+                return { success: false, errors };
+            }
+
+            // Extraire le frontmatter
+            const frontmatterMatch = content.match(/^---([\s\S]*?)---/);
+            if (!frontmatterMatch) {
+                errors.push({
+                    line: 1,
+                    message: 'Frontmatter YAML invalide ou manquant',
+                    type: 'error'
+                });
+                return { success: false, errors };
+            }
+
+            // Parser le frontmatter
+            const frontmatter = yaml.parse(frontmatterMatch[1]);
+            currentLine = frontmatterMatch[0].split('\n').length;
+
+            // Valider les champs requis
+            if (!frontmatter.title) {
+                errors.push({
+                    line: currentLine,
+                    message: 'Le titre est requis dans le frontmatter',
+                    type: 'error'
+                });
+            }
+
+            // Extraire le contenu principal
+            const mainContent = content.slice(frontmatterMatch[0].length).trim();
+            const sections = this.parseSections(mainContent);
+            currentLine += mainContent.split('\n').length;
+
+            // Créer la note
+            const note: Note = {
+                id: uuidv4(),
+                title: frontmatter.title,
+                content: sections.content,
+                tags: Array.isArray(frontmatter.tags) ? frontmatter.tags : [],
+                metadata: {
+                    createdAt: frontmatter.created_at || new Date().toISOString(),
+                    updatedAt: frontmatter.updated_at || new Date().toISOString(),
+                    ...frontmatter
+                }
+            };
+
+            // Parser les flashcards
+            const flashcards = this.parseFlashcards(sections.flashcards, note.id);
+
+            if (errors.length > 0) {
+                return {
+                    success: false,
+                    errors,
+                    data: { note, flashcards }
+                };
+            }
+
+            return {
+                success: true,
+                errors: [],
+                data: { note, flashcards }
+            };
+
+        } catch (error: any) {
+            errors.push({
+                line: currentLine,
+                message: `Erreur lors du parsing: ${error.message}`,
+                type: 'error'
+            });
+            return { success: false, errors };
+        }
+    }
+
+    /**
+     * Parse les différentes sections du contenu Markdown
+     */
+    private parseSections(content: string): { content: string, flashcards: string } {
+        const flashcardsIndex = content.indexOf('## Flashcards');
+
+        if (flashcardsIndex === -1) {
+            return {
+                content: content.trim(),
+                flashcards: ''
+            };
+        }
+
+        return {
+            content: content.slice(0, flashcardsIndex).trim(),
+            flashcards: content.slice(flashcardsIndex).trim()
+        };
+    }
+
+    /**
+     * Parse la section des flashcards et crée les objets correspondants
+     */
+    private parseFlashcards(content: string, noteId: string): Flashcard[] {
+        if (!content) return [];
+
+        const flashcards: Flashcard[] = [];
+        const flashcardBlocks = content.split(/(?=### Flashcard \d+)/);
+
+        for (const block of flashcardBlocks) {
+            if (!block.trim()) continue;
+
+            const questionMatch = block.match(/\*\*Question:\*\*\s*([\s\S]*?)(?=\*\*Réponse:\*\*|$)/);
+            const answerMatch = block.match(/\*\*Réponse:\*\*\s*([\s\S]*?)(?=### Flashcard|\s*$)/);
+
+            if (questionMatch && answerMatch) {
+                flashcards.push({
+                    id: uuidv4(),
+                    question: questionMatch[1].trim(),
+                    answer: answerMatch[1].trim(),
+                    tags: [],
+                    sourceNoteId: noteId,
+                    reviewCount: 0,
+                    createdAt: new Date(),
+                    updatedAt: new Date()
+                });
+            }
+        }
+
+        return flashcards;
+    }
+
+    /**
+     * Valide le format d'un fichier Markdown
+     */
+    public validateMarkdown(content: string): MarkdownParseError[] {
+        const errors: MarkdownParseError[] = [];
+        let currentLine = 1;
+
+        // Vérifier la présence du frontmatter
+        if (!content.startsWith('---')) {
+            errors.push({
+                line: 1,
+                message: 'Le fichier doit commencer par un frontmatter YAML (---)',
+                type: 'error'
+            });
+        }
+
+        // Vérifier la structure du frontmatter
+        const frontmatterMatch = content.match(/^---([\s\S]*?)---/);
+        if (!frontmatterMatch) {
+            errors.push({
+                line: 1,
+                message: 'Frontmatter YAML invalide ou manquant',
+                type: 'error'
+            });
+            return errors;
+        }
+
+        try {
+            const frontmatter = yaml.parse(frontmatterMatch[1]);
+            currentLine = frontmatterMatch[0].split('\n').length;
+
+            // Vérifier les champs requis
+            if (!frontmatter.title) {
+                errors.push({
+                    line: currentLine,
+                    message: 'Le titre est requis dans le frontmatter',
+                    type: 'error'
+                });
+            }
+
+            if (!frontmatter.tags || !Array.isArray(frontmatter.tags)) {
+                errors.push({
+                    line: currentLine,
+                    message: 'Les tags doivent être un tableau',
+                    type: 'warning'
+                });
+            }
+
+            // Vérifier les dates
+            if (frontmatter.created_at && isNaN(Date.parse(frontmatter.created_at))) {
+                errors.push({
+                    line: currentLine,
+                    message: 'Le format de created_at est invalide',
+                    type: 'warning'
+                });
+            }
+
+            if (frontmatter.updated_at && isNaN(Date.parse(frontmatter.updated_at))) {
+                errors.push({
+                    line: currentLine,
+                    message: 'Le format de updated_at est invalide',
+                    type: 'warning'
+                });
+            }
+        } catch (error: any) {
+            errors.push({
+                line: currentLine,
+                message: `Erreur de parsing YAML: ${error.message}`,
+                type: 'error'
+            });
+        }
+
+        return errors;
+    }
+} 

--- a/backend/src/services/MarkdownService.ts
+++ b/backend/src/services/MarkdownService.ts
@@ -1,0 +1,237 @@
+import { Note } from '../types/note';
+import { Flashcard } from '../storage/FlashcardRepository';
+import matter from 'gray-matter';
+import yaml from 'yaml';
+
+// Structure d'une section Markdown
+interface MarkdownSection {
+    title: string;
+    content: string;
+}
+
+export class MarkdownService {
+    private static instance: MarkdownService;
+
+    private constructor() { }
+
+    public static getInstance(): MarkdownService {
+        if (!MarkdownService.instance) {
+            MarkdownService.instance = new MarkdownService();
+        }
+        return MarkdownService.instance;
+    }
+
+    // Méthodes d'export
+    public toMarkdown(note: Note, flashcards: Flashcard[]): { markdown: string; filename: string } {
+        const markdown = this.noteToMarkdown(note, flashcards);
+        const filename = this.createFilename(note);
+
+        return { markdown, filename };
+    }
+
+    public toMarkdownCollection(notes: Note[], flashcardsMap: Map<string, Flashcard[]>): string {
+        if (notes.length === 0) {
+            throw new Error('Aucune note fournie');
+        }
+
+        const exports = notes.map(note => {
+            const flashcards = flashcardsMap.get(note.id) || [];
+            return this.noteToMarkdown(note, flashcards);
+        });
+
+        return exports.join('\n\n---\n\n');
+    }
+
+    public exportNotes(notes: Note[], flashcardsMap: Map<string, Flashcard[]>): Map<string, string> {
+        const exports = new Map<string, string>();
+
+        for (const note of notes) {
+            const flashcards = flashcardsMap.get(note.id) || [];
+            const content = this.noteToMarkdown(note, flashcards);
+            const filename = this.createFilename(note);
+            exports.set(filename, content);
+        }
+
+        return exports;
+    }
+
+    // Méthodes d'import
+    public parseMarkdown(content: string): Omit<Note, 'id'> {
+        const { data, content: markdownContent } = matter(content);
+        const sections = this.parseMarkdownSections(markdownContent);
+
+        // Extraire les tags de la section dédiée s'ils existent
+        const tagsSection = sections.find(s => s.title === 'Tags');
+        const tags = tagsSection
+            ? this.parseListItems(tagsSection.content)
+            : (Array.isArray(data.tags) ? data.tags : []);
+
+        // Extraire le contenu principal
+        const contentSection = sections.find(s => s.title === 'Contenu');
+        const mainContent = contentSection ? contentSection.content : markdownContent;
+
+        // Extraire les métadonnées
+        const metadataSection = sections.find(s => s.title === 'Métadonnées');
+        const metadata = this.parseMetadata(metadataSection?.content || '', data);
+
+        return {
+            title: data.title || sections[0]?.content || 'Sans titre',
+            content: mainContent.trim(),
+            tags,
+            metadata
+        };
+    }
+
+    // Méthodes privées pour l'export
+    private noteToMarkdown(note: Note, flashcards: Flashcard[]): string {
+        const sections = [
+            '---',
+            this.formatFrontMatter(note),
+            '---',
+            '',
+            '# ' + note.title,
+            ''
+        ];
+
+        // Ajouter les tags s'il y en a
+        if (note.tags.length > 0) {
+            sections.push('## Tags');
+            sections.push('');
+            sections.push(note.tags.map(tag => `- ${tag}`).join('\n'));
+            sections.push('');
+        }
+
+        // Ajouter le contenu principal
+        sections.push('## Contenu');
+        sections.push('');
+        sections.push(note.content.trim());
+
+        // Ajouter les flashcards s'il y en a
+        if (flashcards.length > 0) {
+            sections.push('');
+            sections.push('## Flashcards');
+            sections.push('');
+            sections.push(this.formatFlashcards(flashcards));
+        }
+
+        // Ajouter les métadonnées
+        sections.push('');
+        sections.push('## Métadonnées');
+        sections.push('');
+        sections.push(`- Date de création : ${note.metadata?.createdAt || new Date().toISOString()}`);
+        sections.push(`- Dernière modification : ${note.metadata?.updatedAt || new Date().toISOString()}`);
+
+        // Ajouter les autres métadonnées s'il y en a
+        const otherMetadata = { ...note.metadata };
+        delete otherMetadata.createdAt;
+        delete otherMetadata.updatedAt;
+
+        if (Object.keys(otherMetadata).length > 0) {
+            Object.entries(otherMetadata).forEach(([key, value]) => {
+                sections.push(`- ${key} : ${value}`);
+            });
+        }
+
+        return sections.join('\n');
+    }
+
+    private formatFrontMatter(note: Note): string {
+        const frontMatter: Record<string, unknown> = {
+            title: note.title,
+            tags: note.tags,
+            createdAt: note.metadata?.createdAt || new Date().toISOString(),
+            updatedAt: note.metadata?.updatedAt || new Date().toISOString(),
+            ...note.metadata
+        };
+
+        // On retire ces champs car ils sont déjà au premier niveau
+        if ('createdAt' in frontMatter) delete frontMatter.createdAt;
+        if ('updatedAt' in frontMatter) delete frontMatter.updatedAt;
+
+        return yaml.stringify(frontMatter).trim();
+    }
+
+    private formatFlashcards(flashcards: Flashcard[]): string {
+        if (flashcards.length === 0) return '';
+
+        return flashcards.map(fc => (
+            `### Question\n${fc.question}\n\n### Réponse\n${fc.answer}`
+        )).join('\n\n');
+    }
+
+    private createFilename(note: Note): string {
+        return note.title
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+            + '.md';
+    }
+
+    // Méthodes privées pour l'import
+    private parseMarkdownSections(content: string): MarkdownSection[] {
+        const sections: MarkdownSection[] = [];
+        const lines = content.split('\n');
+        let currentSection: MarkdownSection | null = null;
+
+        for (const line of lines) {
+            if (line.startsWith('## ')) {
+                if (currentSection) {
+                    sections.push({
+                        title: currentSection.title,
+                        content: currentSection.content.trim()
+                    });
+                }
+                currentSection = {
+                    title: line.substring(3).trim(),
+                    content: ''
+                };
+            } else if (currentSection) {
+                currentSection.content += line + '\n';
+            }
+        }
+
+        if (currentSection) {
+            sections.push({
+                title: currentSection.title,
+                content: currentSection.content.trim()
+            });
+        }
+
+        return sections;
+    }
+
+    private parseListItems(content: string): string[] {
+        return content
+            .split('\n')
+            .filter(line => line.trim().startsWith('-'))
+            .map(line => line.substring(line.indexOf('-') + 1).trim());
+    }
+
+    private parseMetadata(content: string, frontmatter: any): Record<string, any> {
+        const metadata: Record<string, any> = {
+            createdAt: frontmatter.createdAt || new Date().toISOString(),
+            updatedAt: frontmatter.updatedAt || new Date().toISOString()
+        };
+
+        // Parser les métadonnées de la section dédiée
+        const lines = content.split('\n');
+        for (const line of lines) {
+            if (line.includes(':')) {
+                const [key, value] = line.split(':').map(s => s.trim());
+                if (key.startsWith('- ')) {
+                    const cleanKey = key.substring(2);
+                    metadata[cleanKey] = value;
+                }
+            }
+        }
+
+        // Ajouter les autres métadonnées du frontmatter
+        for (const [key, value] of Object.entries(frontmatter)) {
+            if (!['title', 'tags', 'createdAt', 'updatedAt'].includes(key)) {
+                metadata[key] = value;
+            }
+        }
+
+        return metadata;
+    }
+} 

--- a/backend/src/services/NoteService.ts
+++ b/backend/src/services/NoteService.ts
@@ -1,0 +1,33 @@
+import { Note } from '../types/note';
+import { NoteRepository } from '../storage/NoteRepository';
+
+class NoteService {
+    private static instance: NoteService;
+    private noteRepo: NoteRepository;
+
+    private constructor() {
+        this.noteRepo = NoteRepository.getInstance();
+    }
+
+    public static getInstance(): NoteService {
+        if (!NoteService.instance) {
+            NoteService.instance = new NoteService();
+        }
+        return NoteService.instance;
+    }
+
+    async createNote(note: Omit<Note, 'id'>): Promise<Note> {
+        return this.noteRepo.createNote(note);
+    }
+
+    async updateNote(id: string, note: Partial<Note>): Promise<Note | null> {
+        return this.noteRepo.updateNote(id, note);
+    }
+
+    async findNoteByTitle(title: string): Promise<Note | null> {
+        const notes = await this.noteRepo.searchNotes(title);
+        return notes.find(note => note.title.toLowerCase() === title.toLowerCase()) || null;
+    }
+}
+
+export const noteService = NoteService.getInstance(); 

--- a/backend/src/types/markdown.ts
+++ b/backend/src/types/markdown.ts
@@ -1,0 +1,19 @@
+import { Note } from './note';
+import { Flashcard } from '../storage/FlashcardRepository';
+
+export interface MarkdownImportResult {
+    note: Note;
+    flashcards: Flashcard[];
+}
+
+export interface MarkdownParseError {
+    line: number;
+    message: string;
+    type: 'error' | 'warning';
+}
+
+export interface MarkdownParseResult {
+    success: boolean;
+    data?: MarkdownImportResult;
+    errors: MarkdownParseError[];
+} 

--- a/frontend/src/components/ImportDialog.tsx
+++ b/frontend/src/components/ImportDialog.tsx
@@ -1,0 +1,234 @@
+import React, { useState, useRef, useEffect } from 'react';
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    Box,
+    Typography,
+    Alert,
+    LinearProgress,
+    List,
+    ListItem,
+    ListItemText,
+    ListItemIcon,
+    IconButton,
+    Tooltip,
+    FormControlLabel,
+    Switch,
+} from '@mui/material';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+import DeleteIcon from '@mui/icons-material/Delete';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import WarningIcon from '@mui/icons-material/Warning';
+
+interface ImportDialogProps {
+    open: boolean;
+    onClose: () => void;
+    onImport: (files: File[], options: ImportOptions) => Promise<void>;
+}
+
+interface ImportOptions {
+    overwrite: boolean;
+    skipDuplicates: boolean;
+}
+
+const ImportDialog: React.FC<ImportDialogProps> = ({ open, onClose, onImport }) => {
+    const [files, setFiles] = useState<File[]>([]);
+    const [importing, setImporting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [options, setOptions] = useState<ImportOptions>({
+        overwrite: false,
+        skipDuplicates: true,
+    });
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (open) {
+            setFiles([]);
+        }
+    }, [open]);
+
+    const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const selectedFiles = Array.from(event.target.files || []);
+        const markdownFiles = selectedFiles.filter(file =>
+            file.type === 'text/markdown' || file.name.endsWith('.md')
+        );
+
+        if (markdownFiles.length !== selectedFiles.length) {
+            setError('Certains fichiers ont été ignorés car ils ne sont pas au format Markdown (.md)');
+        }
+
+        setFiles(prevFiles => [...prevFiles, ...markdownFiles]);
+        if (fileInputRef.current) {
+            fileInputRef.current.value = '';
+        }
+    };
+
+    const handleRemoveFile = (index: number) => {
+        setFiles(prevFiles => prevFiles.filter((_, i) => i !== index));
+    };
+
+    const handleImport = async () => {
+        if (files.length === 0) {
+            setError('Veuillez sélectionner au moins un fichier');
+            return;
+        }
+
+        try {
+            setImporting(true);
+            setError(null);
+            await onImport(files, options);
+            onClose();
+        } catch (err) {
+            setError('Une erreur est survenue lors de l\'import');
+        } finally {
+            setImporting(false);
+        }
+    };
+
+    const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        const droppedFiles = Array.from(event.dataTransfer.files);
+        const markdownFiles = droppedFiles.filter(file =>
+            file.type === 'text/markdown' || file.name.endsWith('.md')
+        );
+
+        if (markdownFiles.length !== droppedFiles.length) {
+            setError('Certains fichiers ont été ignorés car ils ne sont pas au format Markdown (.md)');
+        }
+
+        setFiles(prevFiles => [...prevFiles, ...markdownFiles]);
+    };
+
+    const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onClose={!importing ? onClose : undefined}
+            maxWidth="sm"
+            fullWidth
+        >
+            <DialogTitle>Importer des notes</DialogTitle>
+            <DialogContent>
+                <Box sx={{ mb: 2 }}>
+                    <Typography variant="body1" gutterBottom>
+                        Sélectionnez les fichiers Markdown (.md) à importer.
+                    </Typography>
+                    <Box
+                        sx={{
+                            border: '2px dashed #ccc',
+                            borderRadius: 1,
+                            p: 3,
+                            textAlign: 'center',
+                            bgcolor: 'background.default',
+                            cursor: 'pointer',
+                            '&:hover': {
+                                borderColor: 'primary.main',
+                            },
+                        }}
+                        onClick={() => fileInputRef.current?.click()}
+                        onDrop={handleDrop}
+                        onDragOver={handleDragOver}
+                    >
+                        <input
+                            type="file"
+                            ref={fileInputRef}
+                            onChange={handleFileChange}
+                            accept=".md"
+                            multiple
+                            style={{ display: 'none' }}
+                        />
+                        <CloudUploadIcon sx={{ fontSize: 48, color: 'primary.main', mb: 1 }} />
+                        <Typography>
+                            Glissez-déposez vos fichiers ici ou cliquez pour sélectionner
+                        </Typography>
+                    </Box>
+                </Box>
+
+                <Box sx={{ mb: 2 }}>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={options.skipDuplicates}
+                                onChange={(e) => setOptions({ ...options, skipDuplicates: e.target.checked })}
+                            />
+                        }
+                        label="Ignorer les doublons"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={options.overwrite}
+                                onChange={(e) => setOptions({ ...options, overwrite: e.target.checked })}
+                                disabled={options.skipDuplicates}
+                            />
+                        }
+                        label="Écraser les notes existantes"
+                    />
+                </Box>
+
+                {files.length > 0 && (
+                    <List>
+                        {files.map((file, index) => (
+                            <ListItem
+                                key={index}
+                                secondaryAction={
+                                    <Tooltip title="Supprimer">
+                                        <IconButton
+                                            edge="end"
+                                            aria-label="delete"
+                                            onClick={() => handleRemoveFile(index)}
+                                            disabled={importing}
+                                        >
+                                            <DeleteIcon />
+                                        </IconButton>
+                                    </Tooltip>
+                                }
+                            >
+                                <ListItemIcon>
+                                    <CheckCircleIcon color="success" />
+                                </ListItemIcon>
+                                <ListItemText
+                                    primary={file.name}
+                                    secondary={`${(file.size / 1024).toFixed(1)} KB`}
+                                />
+                            </ListItem>
+                        ))}
+                    </List>
+                )}
+
+                {error && (
+                    <Alert severity="error" sx={{ mt: 2 }}>
+                        {error}
+                    </Alert>
+                )}
+
+                {importing && (
+                    <Box sx={{ width: '100%', mt: 2 }}>
+                        <LinearProgress />
+                    </Box>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} disabled={importing}>
+                    Annuler
+                </Button>
+                <Button
+                    onClick={handleImport}
+                    variant="contained"
+                    disabled={files.length === 0 || importing}
+                >
+                    Importer
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default ImportDialog; 

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,1 @@
+export const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api'; 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { API_URL } from '../config';
 
 // Création d'une instance d'axios avec une configuration de base
 const api = axios.create({
@@ -17,6 +18,61 @@ export const exportNote = async (noteId: string): Promise<Blob> => {
 export const exportAllNotes = async (): Promise<Blob> => {
   const response = await api.get('/notes/export-all', { responseType: 'blob' });
   return response.data;
+};
+
+interface ImportOptions {
+  overwrite: boolean;
+  skipDuplicates: boolean;
+}
+
+// Import d'une seule note
+export const importNote = async (file: File, options: ImportOptions) => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  // Ajout des options comme un objet JSON pour préserver le typage
+  const optionsBlob = new Blob(
+    [JSON.stringify(options)],
+    { type: 'application/json' }
+  );
+  formData.append('options', optionsBlob);
+
+  const response = await fetch(`${API_URL}/notes/import`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.message || 'Erreur lors de l\'import de la note');
+  }
+
+  return response.json();
+};
+
+// Import de plusieurs notes
+export const importNotes = async (files: File[], options: ImportOptions) => {
+  const formData = new FormData();
+  files.forEach(file => formData.append('file', file));
+
+  // Ajout des options comme un objet JSON pour préserver le typage
+  const optionsBlob = new Blob(
+    [JSON.stringify(options)],
+    { type: 'application/json' }
+  );
+  formData.append('options', optionsBlob);
+
+  const response = await fetch(`${API_URL}/notes/import-bulk`, {
+    method: 'POST',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.message || 'Erreur lors de l\'import des notes');
+  }
+
+  return response.json();
 };
 
 export default api; 


### PR DESCRIPTION
- Add markdown import service with UTF-8 support

- Implement bulk import functionality

- Add import dialog with file selection reset

- Update export format to include flashcards

- Configure multer for proper file handling

- Add configuration for API URL

- Update debug configuration

Closes #7